### PR TITLE
8 create a script for setting up dev environment automatically

### DIFF
--- a/dev/setup.js
+++ b/dev/setup.js
@@ -1,0 +1,31 @@
+const { exec } = require("child_process");
+const axios = require("axios");
+const dotenv = require("dotenv");
+
+dotenv.config();
+
+const setup = async () => {
+    console.log("Setting up webhook");
+    try {
+        const res = await axios.get("http://localhost:4040/api/tunnels");
+        const data = res.data;
+
+        if (!data || data.tunnels.length === 0) {
+            console.log("Tunnel not started. Retrying in 2 seconds");
+            setTimeout(setup, 2000);
+        }
+
+        const publicUrl = data.tunnels[0].public_url;
+        console.log(`Public URL is: ${publicUrl}`);
+        console.log(`Bot token is: ${process.env.BOT_TOKEN}`);
+
+        await axios.get(
+            `https://api.telegram.org/bot${process.env.BOT_TOKEN}/setWebhook?url=${publicUrl}/api/${process.env.BOT_TOKEN}`
+        );
+        console.log("Webhook is set successfully");
+    } catch (error) {
+        console.log(`Error in setup.js: ${error}`);
+    }
+};
+
+setup();

--- a/dev/setup.js
+++ b/dev/setup.js
@@ -1,4 +1,4 @@
-const { exec } = require("child_process");
+const express = require('express');
 const axios = require("axios");
 const dotenv = require("dotenv");
 
@@ -29,3 +29,19 @@ const setup = async () => {
 };
 
 setup();
+
+const app = express();
+
+app.listen(3001, () => {
+    console.log("You can start development")
+});
+
+
+process.on("SIGINT", async function () {
+    const appURL = "https://telegram-bot-with-sheets-api.vercel.app";
+    await axios.get(
+        `https://api.telegram.org/bot${process.env.BOT_TOKEN}/setWebhook?url=${appURL}/api/${process.env.BOT_TOKEN}`
+    );
+    console.log("\nProduction webhook set. Exiting app.");
+    process.exit();
+});

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+osascript -e 'tell app "Terminal"
+    do script "cd ~/Documents/Projects_Or_Trials/TelegramBot && nodemon ./api/index.js"
+    do script "ngrok http 8080"
+    do script "cd ~/Documents/Projects_Or_Trials/TelegramBot && node ./dev/setup.js"
+end tell'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "This takes messages from the telegram bot and fills up the GSheet for tracking expenses\"",
     "main": "app.js",
     "scripts": {
-        "dev": "nodemon api/index.js",
+        "dev": "bash dev/setup.sh",
         "start": "node api/index.js",
         "test": "echo \"Error: no test specified\" && exit 1"
     },


### PR DESCRIPTION
Now instead of running the server in nodemon, then creating a public url using ngrok, and then setting webhook using postman, now just run 'npm run dev'. All this is now done programatically.